### PR TITLE
Added missing dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+
+debian/.debhelper/
+debian/debhelper-build-stamp
+debian/files
+debian/qt-heif-image-plugin.debhelper.log
+debian/qt-heif-image-plugin.substvars
+debian/qt-heif-image-plugin/
+obj-*-linux-gnu/

--- a/debian/control
+++ b/debian/control
@@ -4,12 +4,15 @@ Maintainer: Xu Shaohua <xushaohua2016@outlook.com>
 Build-Depends: debhelper (>= 9),
     cmake,
     libheif-dev,
+    qtbase5-dev,
 Standards-Version: 3.9.8
 Section: libs
-Homepage: https://github.com/xushaohua/qt-heifimageplugin
+Homepage: https://github.com/jakar/qt-heif-image-plugin
 
 Package: qt-heif-image-plugin
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
+Conflicts: qt-heifimageplugin
+Replaces: qt-heifimageplugin
 Description: heif plugin for Qt
  Wrapper of libheif for Qt image

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,6 +1,6 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: qt-heif-image-plugin
-Source: https://github.com/xushaohua/qt-heifimageplugin
+Source: https://github.com/jakar/qt-heif-image-plugin
 
 Files: *
 Copyright: Jake Harr <jakeharr@gmail.com>


### PR DESCRIPTION
I think it would be better to use https://github.com/jakar/qt-heif-image-plugin as homepage link in debian metadata.

If you want to release a new version, just run `dch -i` in root of project folder, which will generate a new entry in `debian/changelog`. Or you may notify me to update that file and I'll create pull requests to do so.