### PR TITLE
Add support for AVIF

### DIFF
--- a/src/qheifhandler_p.h
+++ b/src/qheifhandler_p.h
@@ -39,6 +39,7 @@ public:
         HeifSequence,
         Heic,
         HeicSequence,
+        Avif,
     };
 
     explicit QHeifHandler();


### PR DESCRIPTION
AVIF is supported by latest versions of libheif. The only major change was
to add avif to the detection logic.

Tested on dumageview with a few sample AVIF files:
* https://github.com/link-u/avif-sample-images/blob/master/kimono.avif
* https://github.com/link-u/avif-sample-images/blob/master/fox.profile0.10bpc.yuv420.odd-width.odd-height.avif

![Screenshot from 2021-06-17 17-52-47](https://user-images.githubusercontent.com/1310299/122489596-df190380-cf94-11eb-8722-5ab918e5943d.png)
![Screenshot from 2021-06-17 17-53-27](https://user-images.githubusercontent.com/1310299/122489621-f0621000-cf94-11eb-9b0e-10de2c5389a4.png)
